### PR TITLE
Personal info edit page

### DIFF
--- a/api/database/db.sql
+++ b/api/database/db.sql
@@ -16,6 +16,7 @@ CREATE TABLE IF NOT EXISTS personal_information (
     first_name VARCHAR(255) NOT NULL,
     middle_initial CHAR(1),
     last_name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL,    -- Note, this email can or not be different from the user's account
     phone_number VARCHAR(20),   -- Formato 123-123-1234
     address VARCHAR(255),   -- La dirección completa
     socials VARCHAR(255),   -- Links a redes sociales separados por coma

--- a/api/database/db.sql
+++ b/api/database/db.sql
@@ -9,21 +9,6 @@ CREATE TABLE IF NOT EXISTS users (
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP
 );
 
--- Updated Personal Information Table
-CREATE TABLE IF NOT EXISTS personal_information (
-    personal_info_id SERIAL PRIMARY KEY,
-    user_id INTEGER NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
-    first_name VARCHAR(255) NOT NULL,
-    middle_initial CHAR(1),
-    last_name VARCHAR(255) NOT NULL,
-    email VARCHAR(255) NOT NULL,    -- Note, this email can or not be different from the user's account
-    phone_number VARCHAR(20),   -- Formato 123-123-1234
-    address VARCHAR(255),   -- La dirección completa
-    socials VARCHAR(255),   -- Links a redes sociales separados por coma
-    summary TEXT,
-    profile TEXT
-);
-
 --PAST RESUME TABLE
 CREATE TABLE IF NOT EXISTS resumes (
     resume_id SERIAL PRIMARY KEY,
@@ -50,6 +35,20 @@ CREATE TABLE IF NOT EXISTS resumes_v2 (
     name VARCHAR(255) NOT NULL,
     title VARCHAR(255),
     created_at DATE DEFAULT CURRENT_DATE
+);
+
+-- Updated Personal Information Table
+CREATE TABLE IF NOT EXISTS personal_information (
+    personal_info_id SERIAL PRIMARY KEY,
+    resume_id INTEGER NOT NULL REFERENCES resumes_v2(resume_id) ON DELETE CASCADE,
+    first_name VARCHAR(255) NOT NULL,
+    middle_initial CHAR(1),
+    last_name VARCHAR(255) NOT NULL,
+    email VARCHAR(255) NOT NULL,    -- Note, this email can or not be different from the user's account
+    phone_number VARCHAR(20),   -- Formato 123-123-1234
+    address VARCHAR(255),   -- La dirección completa
+    socials VARCHAR(255),   -- Links a redes sociales separados por coma
+    summary TEXT
 );
 
 -- Work Experience (references resumes instead of users)

--- a/api/src/controllers/personal.info.controller.js
+++ b/api/src/controllers/personal.info.controller.js
@@ -1,9 +1,9 @@
 const pool = require('../db');
 
 const getPersonalInfo = async (req, res, next) => {
-    const { user_id } = req.params; // Assuming route is defined as /personal-info/:user_id
+    const { resume_id } = req.params; // Assuming route is defined as /personal-info/:resume_id
     try {
-        const info = await pool.query('SELECT * FROM personal_information WHERE user_id = $1', [user_id]);
+        const info = await pool.query('SELECT * FROM personal_information WHERE resume_id = $1', [resume_id]);
         if (info.rows.length === 0) {
             return res.status(404).json({ message: "Personal information not found" });
         }
@@ -15,11 +15,11 @@ const getPersonalInfo = async (req, res, next) => {
 
 
 const savePersonalInfo = async (req, res, next) => {
-    const { user_id, first_name, middle_initial, last_name, phone_number, address, socials, summary, profile } = req.body;
+    const { resume_id, first_name, middle_initial, last_name, email, phone_number, address, socials, summary } = req.body;
     try {
         const newInfo = await pool.query(
-            'INSERT INTO personal_information (user_id, first_name, middle_initial, last_name, phone_number, address, socials, summary, profile) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING *',
-            [user_id, first_name, middle_initial, last_name, phone_number, address, socials, summary, profile]
+            'INSERT INTO personal_information (resume_id, first_name, middle_initial, last_name, email, phone_number, address, socials, summary) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9) RETURNING *',
+            [resume_id, first_name, middle_initial, last_name, email, phone_number, address, socials, summary]
         );
         res.json(newInfo.rows[0]);
     } catch (error) {
@@ -29,9 +29,9 @@ const savePersonalInfo = async (req, res, next) => {
 
 
 const deletePersonalInfo = async (req, res, next) => {
-    const { personal_info_id } = req.params;
+    const { resume_id } = req.params;
     try {
-        const result = await pool.query('DELETE FROM personal_information WHERE personal_info_id = $1 RETURNING *', [personal_info_id]);
+        const result = await pool.query('DELETE FROM personal_information WHERE resume_id = $1 RETURNING *', [resume_id]);
 
         if (result.rows.length === 0) {
             return res.status(404).json({ message: "Personal information not found" });
@@ -44,15 +44,15 @@ const deletePersonalInfo = async (req, res, next) => {
 }
 
 const updatePersonalInfo = async (req, res, next) => {
-    const { personal_info_id } = req.params;
-    const { first_name, middle_initial, last_name, phone_number, address, socials, summary, profile } = req.body;
+    const { resume_id } = req.params;
+    const { first_name, middle_initial, last_name, email, phone_number, address, socials, summary } = req.body;
     try {
         const updatedInfo = await pool.query(
-            'UPDATE personal_information SET first_name = $1, middle_initial = $2, last_name = $3, phone_number = $4, address = $5, socials = $6, summary = $7, profile = $8 WHERE personal_info_id = $9 RETURNING *',
-            [first_name, middle_initial, last_name, phone_number, address, socials, summary, profile, personal_info_id]
+            'UPDATE personal_information SET first_name = $1, middle_initial = $2, last_name = $3, phone_number = $4, address = $5, socials = $6, summary = $7, email = $8 WHERE resume_id = $9 RETURNING *',
+            [first_name, middle_initial, last_name, phone_number, address, socials, summary, email, resume_id]
         );
         if (updatedInfo.rows.length === 0) {
-            return res.status(404).json({ message: "Personal information not found" });
+            return res.status(404).json({ message: `Personal information not found for resume ${resume_id}` });
         }
         res.json(updatedInfo.rows[0]);
     } catch (error) {

--- a/api/src/routes/personal.info.routes.js
+++ b/api/src/routes/personal.info.routes.js
@@ -8,9 +8,9 @@ const {
 
 const router = Router();
 
-router.get('/personal-info/user/:user_id', getPersonalInfo); // Fetch by user_id
+router.get('/personal-info/resume/:resume_id', getPersonalInfo); // Fetch personal info by resume_id
 router.post('/personal-info', savePersonalInfo); // creates new personal info
-router.put('/personal-info/:personal_info_id', updatePersonalInfo); // Update existing personal info
-router.delete('/personal-info/:personal_info_id', deletePersonalInfo); // Delete by personal_info_id
+router.put('/personal-info/resume/:resume_id', updatePersonalInfo); // Update existing personal info by resume_id
+router.delete('/personal-info/resume/:resume_id', deletePersonalInfo); // Delete by personal info by resume_id
 
 module.exports = router;

--- a/ui/client/src/App.js
+++ b/ui/client/src/App.js
@@ -25,8 +25,7 @@ const handleResumeSubmit = (resumeData) => {
 };
   return (
     <UserProvider>
-      // <UserProvider>
-    <BrowserRouter>
+      <BrowserRouter>
         <MenuContainer /> {/* Render the MenuContainer component */}
         <Container>
           <Routes>
@@ -42,7 +41,8 @@ const handleResumeSubmit = (resumeData) => {
             <Route path='/signup' element={<SignUpForm onSignUp={() => {console.log("signed up")}} />} />
             <Route path='/login' element={<LogInForm onLogIn={() => {console.log("Logged in")}} />} />
             <Route path='/resume/datainput' element={<ResumeInput onSubmitResumeForm={() => {console.log("Submitted resume info")}} />} />
-            <Route path='/resume/personalInfo' element={<PersonalInfo />}></Route>
+            <Route path='/resume/:resumeId/personalInfo/new' element={<PersonalInfo />}></Route>
+            <Route path='/resume/:resumeId/personalInfo/edit' element={<PersonalInfo />}></Route>
             <Route path='/resume/education' element={<Education />}></Route>
             <Route path='/resume/preview' element={<PreviewPage />} />
             <Route path='/profile' element={<ProfilePage />} />
@@ -53,6 +53,5 @@ const handleResumeSubmit = (resumeData) => {
         </Container>
       </BrowserRouter>
     </UserProvider>
-  //   </UserProvider>
   );
 }


### PR DESCRIPTION
In this PR I added the necessary capabilities for PersonalInfoPage to support both add and edit personal info forms. I had to change some of the endpoints in the api and update the personal info table in order for it to work. Now, the personal info depends on a resume (from resumes_v2 table in the database).

Note: When adding a new personal info entry related to a resume, the resume relationship with the user must exist before creating a new personal info entry. See how the page url changes for personal info page. 